### PR TITLE
Fix game type conditional in DrawGame

### DIFF
--- a/src/main/java/com/example/simple1/drawgame/DrawGame.java
+++ b/src/main/java/com/example/simple1/drawgame/DrawGame.java
@@ -15,7 +15,7 @@ public class DrawGame {
 
     private static final String GAME_TYPE = "CLICK";//"MOVE";
     private static final int COORDS_ROWS = GAME_TYPE.equals("MOVE") ? 40 : 10;
-    private static final int COORDS_COLS = GAME_TYPE.equals("MOVE ") ? 80 : 20;
+    private static final int COORDS_COLS = GAME_TYPE.equals("MOVE") ? 80 : 20;
     private static final int TOTAL_FIELDS = COORDS_ROWS * COORDS_COLS;
     private static final double WIN_THRESHOLD = 0.5;
 


### PR DESCRIPTION
## Summary
- fix a typo in `DrawGame` that prevented MOVE mode from setting the board width correctly

## Testing
- `bash mvnw -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f46b4c2bc8331b90b4e8739035e67