### PR TITLE
Add lobby list endpoint and back button

### DIFF
--- a/src/main/java/com/example/simple1/controller/DrawGameController.java
+++ b/src/main/java/com/example/simple1/controller/DrawGameController.java
@@ -1,6 +1,7 @@
 package com.example.simple1.controller;
 
 import com.example.simple1.drawgame.dto.DrawGameResponse.FetchLobbyAndGameStateResponse;
+import com.example.simple1.drawgame.dto.DrawGameResponse.ActiveLobbyDto;
 import com.example.simple1.exception.bad_request.BadRequestException;
 import com.example.simple1.service.DrawGameService;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -61,6 +63,11 @@ public class DrawGameController {
     @PostMapping("/fetch-game-state")
     public FetchLobbyAndGameStateResponse fetchGameState(@Valid @RequestBody FetchGameStateRequest fetchGameStateRequest) {
         return drawGameService.fetchGameState(fetchGameStateRequest);
+    }
+
+    @GetMapping("/active-lobbies")
+    public List<ActiveLobbyDto> getActiveLobbies() {
+        return drawGameService.getActiveLobbies();
     }
 
     @Deprecated()

--- a/src/main/java/com/example/simple1/drawgame/dto/DrawGameResponse.java
+++ b/src/main/java/com/example/simple1/drawgame/dto/DrawGameResponse.java
@@ -52,4 +52,11 @@ public class DrawGameResponse {
             double score
     ) {
     }
+
+    public record ActiveLobbyDto(
+            int lobbyId,
+            String lobbyName,
+            int playerCount
+    ) {
+    }
 }

--- a/src/main/java/com/example/simple1/service/DrawGameService.java
+++ b/src/main/java/com/example/simple1/service/DrawGameService.java
@@ -6,6 +6,7 @@ import com.example.simple1.drawgame.dto.DrawGameResponse.DrawGamePlayerDto;
 import com.example.simple1.drawgame.dto.DrawGameResponse.FetchLobbyAndGameStateResponse;
 import com.example.simple1.drawgame.dto.DrawGameResponse.GameStateUpdateResponse;
 import com.example.simple1.drawgame.dto.DrawGameResponse.UpdatedCoordDto;
+import com.example.simple1.drawgame.dto.DrawGameResponse.ActiveLobbyDto;
 import com.example.simple1.exception.bad_request.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -122,6 +123,12 @@ public class DrawGameService {
         if (lobbyId == null || !lobbyIdToGame.containsKey(lobbyId)) {
             throw new BadRequestException("LobbyId '%d' has not been found!".formatted(lobbyId));
         }
+    }
+
+    public List<ActiveLobbyDto> getActiveLobbies() {
+        return lobbyIdToGame.values().stream()
+                .map(game -> new ActiveLobbyDto(game.getGameId(), game.getLobbyName(), game.getPlayers().size()))
+                .toList();
     }
 
     private GameEnterResponse addPlayer(DrawGame drawGame, String playerName) {

--- a/src/main/resources/static/scriptv2.js
+++ b/src/main/resources/static/scriptv2.js
@@ -39,6 +39,8 @@ const gameState = {
     fetchGameStateInterval: null
 }
 
+let activeLobbies = [];
+
 const playBeep = frequency => {
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     if (!AudioCtx) return;
@@ -187,6 +189,14 @@ const renderLobbyMenu = () => {
         context.strokeRect(item.x(), item.y(), item.width, item.height);
         context.fillText(item.text(), item.x() + item.width / 2, item.y() + item.height / 2);
     });
+
+    // active lobbies list
+    context.textAlign = 'left';
+    let lY = canvas.height / 2 + canvasState.tileSize * 8;
+    activeLobbies.forEach(lobby => {
+        context.fillText(`ID ${lobby.lobbyId}: ${lobby.lobbyName} (${lobby.playerCount}/2)`, canvasState.tileSize, lY);
+        lY += canvasState.tileSize * 3;
+    });
 }
 
 const renderGameBackground = timestamp => {
@@ -228,6 +238,19 @@ const renderScore = () => {
     context.strokeStyle = 'black';
     context.lineWidth = 4;
     context.strokeRect(2, 2, bounding.width - 4, canvasState.topOffset - 4)
+
+    // Back button
+    context.beginPath();
+    context.fillStyle = '#bec2ed';
+    context.fillRect(canvasState.tileSize, canvasState.tileSize, canvasState.tileSize * 8, canvasState.tileSize * 3);
+    context.strokeStyle = 'black';
+    context.lineWidth = 4;
+    context.strokeRect(canvasState.tileSize, canvasState.tileSize, canvasState.tileSize * 8, canvasState.tileSize * 3);
+    context.font = `${Math.round(canvasState.tileSize * 2)}px monospace`;
+    context.fillStyle = 'black';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText('Back', canvasState.tileSize * 5, canvasState.tileSize * 2.5);
 
     let textX = canvasState.tileSize * 12;
     let textY = canvasState.tileSize * 3;
@@ -363,6 +386,12 @@ const fetchLobbyAndGameState = async () => {
         });
 }
 
+const fetchActiveLobbies = () => {
+    return fetch(SERVER_ADDRESS + '/epic-draw/active-lobbies')
+        .then(response => response.json())
+        .then(data => { activeLobbies = data; });
+}
+
 
 const fieldPlaceRequest = (updatedCoords) => {
     lobbyState.stompClient.send(
@@ -423,6 +452,17 @@ const handleGameClick = event => {
     const bounding = canvas.getBoundingClientRect();
     const x = event.clientX - bounding.left;
     const y = event.clientY - bounding.top;
+
+    const backBox = {
+        x: canvasState.tileSize,
+        y: canvasState.tileSize,
+        width: canvasState.tileSize * 8,
+        height: canvasState.tileSize * 3
+    };
+    if (x >= backBox.x && x <= backBox.x + backBox.width && y >= backBox.y && y <= backBox.y + backBox.height) {
+        handleLobbyLeave();
+        return;
+    }
 
     const col_idx = Math.floor(x / (4 * canvasState.tileSize));
     const row_idx = Math.floor((y - canvasState.topOffset) / (4 * canvasState.tileSize));
@@ -542,3 +582,6 @@ renderCanvas();
 
 window.addEventListener('resize', renderCanvas);
 canvas.addEventListener('click', handleMenuClick);
+
+fetchActiveLobbies();
+setInterval(fetchActiveLobbies, 5000);


### PR DESCRIPTION
## Summary
- add `ActiveLobbyDto` DTO and `getActiveLobbies` service method
- expose `/active-lobbies` endpoint
- show active lobbies on the lobby menu and periodically refresh
- draw a Back button during the game and allow returning to lobby

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b202ef08331a9527a1a683f9dd6