### PR TITLE
Add join buttons for lobby list

### DIFF
--- a/src/main/java/com/example/simple1/controller/DrawGameController.java
+++ b/src/main/java/com/example/simple1/controller/DrawGameController.java
@@ -1,6 +1,7 @@
 package com.example.simple1.controller;
 
 import com.example.simple1.drawgame.dto.DrawGameResponse.FetchLobbyAndGameStateResponse;
+import com.example.simple1.drawgame.dto.DrawGameResponse.ActiveLobbyDto;
 import com.example.simple1.exception.bad_request.BadRequestException;
 import com.example.simple1.service.DrawGameService;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -61,6 +63,11 @@ public class DrawGameController {
     @PostMapping("/fetch-game-state")
     public FetchLobbyAndGameStateResponse fetchGameState(@Valid @RequestBody FetchGameStateRequest fetchGameStateRequest) {
         return drawGameService.fetchGameState(fetchGameStateRequest);
+    }
+
+    @GetMapping("/active-lobbies")
+    public List<ActiveLobbyDto> getActiveLobbies() {
+        return drawGameService.getActiveLobbies();
     }
 
     @Deprecated()

--- a/src/main/java/com/example/simple1/drawgame/dto/DrawGameResponse.java
+++ b/src/main/java/com/example/simple1/drawgame/dto/DrawGameResponse.java
@@ -52,4 +52,11 @@ public class DrawGameResponse {
             double score
     ) {
     }
+
+    public record ActiveLobbyDto(
+            int lobbyId,
+            String lobbyName,
+            int playerCount
+    ) {
+    }
 }

--- a/src/main/java/com/example/simple1/service/DrawGameService.java
+++ b/src/main/java/com/example/simple1/service/DrawGameService.java
@@ -6,6 +6,7 @@ import com.example.simple1.drawgame.dto.DrawGameResponse.DrawGamePlayerDto;
 import com.example.simple1.drawgame.dto.DrawGameResponse.FetchLobbyAndGameStateResponse;
 import com.example.simple1.drawgame.dto.DrawGameResponse.GameStateUpdateResponse;
 import com.example.simple1.drawgame.dto.DrawGameResponse.UpdatedCoordDto;
+import com.example.simple1.drawgame.dto.DrawGameResponse.ActiveLobbyDto;
 import com.example.simple1.exception.bad_request.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -122,6 +123,12 @@ public class DrawGameService {
         if (lobbyId == null || !lobbyIdToGame.containsKey(lobbyId)) {
             throw new BadRequestException("LobbyId '%d' has not been found!".formatted(lobbyId));
         }
+    }
+
+    public List<ActiveLobbyDto> getActiveLobbies() {
+        return lobbyIdToGame.values().stream()
+                .map(game -> new ActiveLobbyDto(game.getGameId(), game.getLobbyName(), game.getPlayers().size()))
+                .toList();
     }
 
     private GameEnterResponse addPlayer(DrawGame drawGame, String playerName) {


### PR DESCRIPTION
## Summary
- make lobby list interactive with Join buttons
- store dynamic lobby button positions and handle clicks
- reposition Back button to far right of scoreboard

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b202ef08331a9527a1a683f9dd6