### PR TITLE
Improve lobby join UI

### DIFF
--- a/src/main/java/com/example/simple1/service/DrawGameService.java
+++ b/src/main/java/com/example/simple1/service/DrawGameService.java
@@ -127,6 +127,7 @@ public class DrawGameService {
 
     public List<ActiveLobbyDto> getActiveLobbies() {
         return lobbyIdToGame.values().stream()
+                .sorted((g1, g2) -> Integer.compare(g1.getGameId(), g2.getGameId()))
                 .map(game -> new ActiveLobbyDto(game.getGameId(), game.getLobbyName(), game.getPlayers().size()))
                 .toList();
     }

--- a/src/main/resources/static/scriptv2.js
+++ b/src/main/resources/static/scriptv2.js
@@ -40,6 +40,7 @@ const gameState = {
 }
 
 let activeLobbies = [];
+const joinButtons = [];
 
 const playBeep = frequency => {
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
@@ -196,8 +197,34 @@ const renderLobbyMenu = () => {
     // active lobbies list
     context.textAlign = 'left';
     let lY = canvas.height / 2 + canvasState.tileSize * 8;
+    joinButtons.length = 0;
     activeLobbies.forEach(lobby => {
-        context.fillText(`ID ${lobby.lobbyId}: ${lobby.lobbyName} (${lobby.playerCount}/2)`, canvasState.tileSize, lY);
+        const text = `ID ${lobby.lobbyId}: ${lobby.lobbyName} (${lobby.playerCount}/2)`;
+        context.fillText(text, canvasState.tileSize, lY);
+
+        const btn = {
+            lobbyId: lobby.lobbyId,
+            x: () => canvas.width - canvasState.tileSize * 10,
+            y: () => lY - canvasState.tileSize * 1.5,
+            width: canvasState.tileSize * 8,
+            height: canvasState.tileSize * 3
+        };
+        const bx = btn.x();
+        const by = btn.y();
+        context.beginPath();
+        context.fillStyle = '#bec2ed';
+        context.fillRect(bx, by, btn.width, btn.height);
+        context.strokeStyle = 'black';
+        context.lineWidth = 4;
+        context.strokeRect(bx, by, btn.width, btn.height);
+        context.fillStyle = 'black';
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.fillText('Join', bx + btn.width / 2, by + btn.height / 2);
+
+        joinButtons.push(btn);
+
+        context.textAlign = 'left'; // reset for next text
         lY += canvasState.tileSize * 3;
     });
 }
@@ -449,6 +476,17 @@ const handleMenuClick = event => {
         .filter(item => item.viewMode === canvasState.currentViewMode)
         .filter(item => isIntersect(pos, item))
         .forEach(item => item.onclick());
+
+    joinButtons
+        .filter(btn => isIntersect(pos, btn))
+        .forEach(btn => {
+            if (!canvasState.input.username || canvasState.input.username === 'Enter username') {
+                canvasState.input.username = prompt('Please enter your username');
+                renderLobbyMenu();
+                return;
+            }
+            joinGameRequest(btn.lobbyId, canvasState.input.username);
+        });
 };
 
 const handleGameClick = event => {


### PR DESCRIPTION
## Summary
- render join buttons next to active lobbies
- allow clicking to join lobby directly
- keep lobby list sorted server-side

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f59ecbd1c8331852b18eb19bde837